### PR TITLE
Zero buffer pointers on callback exit

### DIFF
--- a/pmemkv/kvengine.cc
+++ b/pmemkv/kvengine.cc
@@ -270,6 +270,8 @@ void value_callback(const char *value, size_t valuebyte, void *context)
 				Py_XDECREF(res);
 			}
 		}
+		entry->value = NULL;
+		entry->length = 0;
 		Py_XDECREF(args);
 	} else {
 		PyErr_SetString(PyExc_MemoryError,
@@ -311,6 +313,11 @@ int key_value_callback(const char *key, size_t keybytes, const char *value,
 		retval = -1;
 	}
 	PyObject *res = PyObject_CallObject((PyObject *)context, args);
+	key_buffer->value=NULL;
+	key_buffer->length=0;
+	value_buffer->value=NULL;
+	value_buffer->length=0;
+
 	Py_DECREF(value_buffer);
 	Py_DECREF(key_buffer);
 	Py_DECREF(args);


### PR DESCRIPTION
Setting buffer to zero partially mitigate issue with using buffer protocol
outside of callback function scope. Currently copying key object outside
of callback function scope ends with empty data.
There is still possibility to copy memoryview object during callback function
use it outside and die.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-python/30)
<!-- Reviewable:end -->
