### PR TITLE
Remove unused return values from C extension

### DIFF
--- a/pmemkv/kvengine.cc
+++ b/pmemkv/kvengine.cc
@@ -341,7 +341,7 @@ pmemkv_NI_GetKeys(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -359,7 +359,7 @@ pmemkv_NI_GetKeysAbove(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -377,7 +377,7 @@ pmemkv_NI_GetKeysBelow(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -396,7 +396,7 @@ pmemkv_NI_GetKeysBetween(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 // "Count" Methods.
@@ -470,7 +470,7 @@ pmemkv_NI_GetAll(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -488,7 +488,7 @@ pmemkv_NI_GetAbove(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -506,7 +506,7 @@ pmemkv_NI_GetBelow(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *
@@ -525,7 +525,7 @@ pmemkv_NI_GetBetween(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 // "Exists" Method.
@@ -555,7 +555,7 @@ pmemkv_NI_Put(PmemkvObject *self, PyObject* args) {
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *pmemkv_NI_GetString(PmemkvObject *self, PyObject *args)
@@ -602,7 +602,7 @@ static PyObject *pmemkv_NI_Get(PmemkvObject *self, PyObject *args)
 		PyErr_SetString(ExceptionDispatcher[result].exception, pmemkv_errormsg());
 		return NULL;
 	}
-	return PyLong_FromLong(result);
+	Py_RETURN_NONE;
 }
 
 static PyObject *


### PR DESCRIPTION
Those return values was always 0 and was not captured in python layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-python/33)
<!-- Reviewable:end -->
