### PR TITLE
doc: enable auto gh-pages docs generation

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #
 
 set -e
+source $(dirname $0)/valid-branches.sh
 
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set " \
@@ -84,6 +85,11 @@ if [ "$COVERAGE" == "1" ]; then
 fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
+
+# Only run doc update on $GITHUB_REPO master or stable branch
+if [[ -z "${TRAVIS_BRANCH}" || -z "${TARGET_BRANCHES[${TRAVIS_BRANCH}]}" || "$TRAVIS_PULL_REQUEST" != "false" || "$TRAVIS_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
+	AUTO_DOC_UPDATE=0
+fi
 
 WORKDIR=/pmemkv-python
 SCRIPTSDIR=$WORKDIR/utils/docker

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2020, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -e
+
+source `dirname $0`/valid-branches.sh
+
+BOT_NAME="pmem-bot"
+USER_NAME="pmem"
+REPO_NAME="pmemkv-python"
+CURR_DIR=$(pwd)
+
+ORIGIN="https://${GITHUB_TOKEN}@github.com/${BOT_NAME}/${REPO_NAME}"
+UPSTREAM="https://github.com/${USER_NAME}/${REPO_NAME}"
+# master or stable-* branch
+TARGET_BRANCH=${TRAVIS_BRANCH}
+VERSION=${TARGET_BRANCHES[$TARGET_BRANCH]}
+
+if [ -z $VERSION ]; then
+	echo "Target location for branch $TARGET_BRANCH is not defined."
+	exit 1
+fi
+
+# Clone repo
+git clone ${ORIGIN}
+cd $CURR_DIR/${REPO_NAME}
+git remote add upstream ${UPSTREAM}
+
+git config --local user.name ${BOT_NAME}
+git config --local user.email "${BOT_NAME}@intel.com"
+
+git remote update
+git checkout -B ${TARGET_BRANCH} upstream/${TARGET_BRANCH}
+
+# Build docs
+cd $CURR_DIR/${REPO_NAME}/doc
+
+make -j$(nproc) html
+cp -r $CURR_DIR/${REPO_NAME}/doc/_build/html $CURR_DIR/
+
+cd $CURR_DIR/${REPO_NAME}
+
+# Checkout gh-pages and copy docs
+GH_PAGES_NAME="gh-pages-for-${TARGET_BRANCH}"
+git checkout -B $GH_PAGES_NAME upstream/gh-pages
+git clean -dfx
+
+# Clean old content, since some files might have been deleted
+rm -rf ./${VERSION}
+mkdir -p ./${VERSION}
+
+cp -r $CURR_DIR/html ./${VERSION}/
+# It seems that gh-pages can't handle dirs starting with '_' (underscore)
+cd ./${VERSION}/html
+mv _static/ static/
+mv _sources/ sources/
+mv _modules/ modules/
+find . -iname "*.html" -exec sed -i 's/_modules/modules/g' {} +
+find . -iname "*.js" -exec sed -i 's/_sources/sources/g' {} +
+find . -iname "*.html" -exec sed -i 's/_sources/sources/g' {} +
+find . -iname "*.html" -exec sed -i 's/_static/static/g' {} +
+
+# Add and push changes.
+# git commit command may fail if there is nothing to commit.
+# In that case we want to force push anyway (there might be open pull request with
+# changes which were reverted).
+git add -A
+git commit -m "doc: automatic gh-pages docs update" && true
+git push -f ${ORIGIN} $GH_PAGES_NAME
+
+# Makes pull request.
+# When there is already an open PR or there are no changes an error is thrown, which we ignore.
+hub pull-request -f -b ${USER_NAME}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} -m "doc: automatic gh-pages docs update" && true
+
+exit 0

--- a/utils/docker/valid-branches.sh
+++ b/utils/docker/valid-branches.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+declare -A TARGET_BRANCHES=(		\
+		["master"]="master"	\
+		["stable-1.0"]="v1.0"	\
+	)


### PR DESCRIPTION
There's a small trick for docs generation and usage on gh-pages - it seems links are not working correctly on gh-pages when a directory starts with an underscore (e.g. "_static"). This PR fixes this problem with an auto docs generation.

to compare: pmem/pmemkv#605

- [x] #40 is merged
- [x] #41 is merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-python/42)
<!-- Reviewable:end -->
