### PR TITLE
doc: enable auto gh-pages docs generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ services:
 
 env:
   matrix:
-      - TYPE=pmemkv-master OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1
-      - TYPE=pmemkv-stable-1.0 OS=ubuntu OS_VER=19.10
-      - TYPE=pmemkv-stable-1.1 OS=ubuntu OS_VER=19.10
-      - TYPE=pmemkv-master OS=fedora OS_VER=31 PUSH_IMAGE=1
-      - TYPE=pmemkv-stable-1.0 OS=fedora OS_VER=31
-      - TYPE=pmemkv-stable-1.1 OS=fedora OS_VER=31
+    - TYPE=pmemkv-master OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1
+    - TYPE=pmemkv-stable-1.0 OS=ubuntu OS_VER=19.10
+    - TYPE=pmemkv-stable-1.1 OS=ubuntu OS_VER=19.10
+    - TYPE=pmemkv-master OS=fedora OS_VER=31 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
+    - TYPE=pmemkv-stable-1.0 OS=fedora OS_VER=31
+    - TYPE=pmemkv-stable-1.1 OS=fedora OS_VER=31
 
 before_install:
   - echo $TRAVIS_COMMIT_RANGE

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #
 
 set -e
+source $(dirname $0)/valid-branches.sh
 
 if [[ -z "$OS" || -z "$OS_VER" ]]; then
 	echo "ERROR: The variables OS and OS_VER have to be set " \
@@ -85,6 +86,11 @@ fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
 
+# Only run doc update on $GITHUB_REPO master or stable branch
+if [[ -z "${TRAVIS_BRANCH}" || -z "${TARGET_BRANCHES[${TRAVIS_BRANCH}]}" || "$TRAVIS_PULL_REQUEST" != "false" || "$TRAVIS_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
+	AUTO_DOC_UPDATE=0
+fi
+
 WORKDIR=/pmemkv-python
 SCRIPTSDIR=$WORKDIR/utils/docker
 
@@ -101,6 +107,7 @@ docker run --network="bridge" --name=$containerName -ti \
 	--env http_proxy=$http_proxy \
 	--env https_proxy=$https_proxy \
 	--env GITHUB_TOKEN=$GITHUB_TOKEN \
+	--env AUTO_DOC_UPDATE=$AUTO_DOC_UPDATE \
 	--env WORKDIR=$WORKDIR \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
 	--env COVERAGE=$COVERAGE \

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -71,9 +71,12 @@ PMEM_IS_PMEM_FORCE=1 python3 basic_example.py
 REST_API_EXAMPLE_DIR="${WORKDIR}/examples/restAPI"
 python3 ${REST_API_EXAMPLE_DIR}/run_example.py
 
-echo
-echo "########################################################"
-echo "### Generating doc"
-echo "########################################################"
-cd $WORKDIR/doc
-make html
+# Create PR with generated docs
+if [[ "$AUTO_DOC_UPDATE" == "1" ]]; then
+	echo
+	echo "########################################################"
+	echo "###Running auto doc update"
+	echo "########################################################"
+
+	$SCRIPTSDIR/run-doc-update.sh
+fi

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2020, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set -e
+
+source `dirname $0`/valid-branches.sh
+
+BOT_NAME="pmem-bot"
+USER_NAME="pmem"
+REPO_NAME="pmemkv-python"
+CURR_DIR=$(pwd)
+
+ORIGIN="https://${GITHUB_TOKEN}@github.com/${BOT_NAME}/${REPO_NAME}"
+UPSTREAM="https://github.com/${USER_NAME}/${REPO_NAME}"
+# master or stable-* branch
+TARGET_BRANCH=${TRAVIS_BRANCH}
+VERSION=${TARGET_BRANCHES[$TARGET_BRANCH]}
+
+if [ -z $VERSION ]; then
+	echo "Target location for branch $TARGET_BRANCH is not defined."
+	exit 1
+fi
+
+# Clone repo
+git clone ${ORIGIN}
+cd $CURR_DIR/${REPO_NAME}
+git remote add upstream ${UPSTREAM}
+
+git config --local user.name ${BOT_NAME}
+git config --local user.email "${BOT_NAME}@intel.com"
+
+git remote update
+git checkout -B ${TARGET_BRANCH} upstream/${TARGET_BRANCH}
+
+# Build docs
+cd $CURR_DIR/${REPO_NAME}/doc
+
+make -j$(nproc) html
+cp -r $CURR_DIR/${REPO_NAME}/doc/_build/html $CURR_DIR/
+
+cd $CURR_DIR/${REPO_NAME}
+
+# Checkout gh-pages and copy docs
+GH_PAGES_NAME="gh-pages-for-${TARGET_BRANCH}"
+git checkout -B $GH_PAGES_NAME upstream/gh-pages
+git clean -dfx
+
+# Clean old content, since some files might have been deleted
+rm -rf ./${VERSION}
+mkdir -p ./${VERSION}
+
+cp -r $CURR_DIR/html ./${VERSION}/
+# It seems that gh-pages can't handle dirs starting with '_' (underscore)
+cd ./${VERSION}/html
+mv _static/ static/
+mv _sources/ sources/
+mv _modules/ modules/
+find . -iname "*.html" -exec sed -i 's/_modules/modules/g' {} +
+find . -iname "*.js" -exec sed -i 's/_sources/sources/g' {} +
+find . -iname "*.html" -exec sed -i 's/_sources/sources/g' {} +
+find . -iname "*.html" -exec sed -i 's/_static/static/g' {} +
+
+# Add and push changes.
+# git commit command may fail if there is nothing to commit.
+# In that case we want to force push anyway (there might be open pull request with
+# changes which were reverted).
+git add -A
+git commit -m "doc: automatic gh-pages docs update" && true
+git push -f ${ORIGIN} $GH_PAGES_NAME
+
+# Makes pull request.
+# When there is already an open PR or there are no changes an error is thrown, which we ignore.
+hub pull-request -f -b ${USER_NAME}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} -m "doc: automatic gh-pages docs update" && true
+
+exit 0

--- a/utils/docker/valid-branches.sh
+++ b/utils/docker/valid-branches.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+declare -A TARGET_BRANCHES=(		\
+		["master"]="master"	\
+		["stable-1.0"]="v1.0"	\
+	)


### PR DESCRIPTION
There's a small trick for docs generation and usage on gh-pages - it seems links are not working correctly on gh-pages when a directory starts with an underscore (e.g. "_static"). This PR fixes this problem with an auto docs generation.

to compare: pmem/pmemkv#605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv-python/44)
<!-- Reviewable:end -->
